### PR TITLE
DevContainer support

### DIFF
--- a/src/hermesbaby/__main__.py
+++ b/src/hermesbaby/__main__.py
@@ -641,7 +641,7 @@ def html_live(
         "--port",
         f"{int(kconfig.syms['BUILD__PORTS__HTML__LIVE'].str_value)}",
     ]
-    if os.environ.get("DEVCONTAINER")!="true":
+    if os.getenv("DEVCONTAINER")!="true":
         extra_args.append("--open-browser")
     else:
         extra_args.append("--host")
@@ -687,7 +687,12 @@ def pdf_live(
         help="Increase verbosity (can be repeated)",
     ),
 ):
-    """Build to format PDF with live reload"""
+    """Build to format PDF with live reload
+
+    Use environment variable DEVCONTAINER=true to modify behaviour:
+    Set host address to 0.0.0.0 to listen to all incoming requests inside the container because localhost is not available.
+    Do not open browser because the browser will open on 0.0.0.0 which is meaningless on host. Let VSCode DevContainer handle the situation.
+    """
 
     _set_env(ctx, part_dir=part)
     _load_config()
@@ -702,8 +707,12 @@ def pdf_live(
         "_tags/.*",
         "--port",
         f"{int(kconfig.syms['BUILD__PORTS__PDF__LIVE'].str_value)}",
-        "--open-browser",
     ]
+    if os.getenv("DEVCONTAINER")!="true":
+        extra_args.append("--open-browser")
+    else:
+        extra_args.append("--host")
+        extra_args.append("0.0.0.0")
     returncode = _build_common(ctx, part=part, builder="latex", tool_name="sphinx-autobuild", extra_args=extra_args)
     sys.exit(returncode)
 

--- a/src/hermesbaby/__main__.py
+++ b/src/hermesbaby/__main__.py
@@ -615,7 +615,12 @@ def html_live(
         help="Increase verbosity (can be repeated)",
     ),
 ):
-    """Build to format HTML with live reload"""
+    """Build to format HTML with live reload
+
+    Use environment variable DEVCONTAINER=true to modify behaviour:
+    Set host address to 0.0.0.0 to listen to all incoming requests inside the container because localhost is not available.
+    Do not open browser because the browser will open on 0.0.0.0 which is meaningless on host. Let VSCode DevContainer handle the situation.
+    """
 
     _set_env(ctx, part_dir=part)
     _load_config()
@@ -635,8 +640,12 @@ def html_live(
         "_tags/.*",
         "--port",
         f"{int(kconfig.syms['BUILD__PORTS__HTML__LIVE'].str_value)}",
-        "--open-browser",
     ]
+    if os.environ.get("DEVCONTAINER")!="true":
+        extra_args.append("--open-browser")
+    else:
+        extra_args.append("--host")
+        extra_args.append("0.0.0.0")
     returncode = _build_common(ctx, part=part, builder="html", tool_name="sphinx-autobuild", extra_args=extra_args)
     sys.exit(returncode)
 


### PR DESCRIPTION
This change introduces a switch to change the behaviour of `hb html-live` and `hb pdf-live` inside a container.

Once you have created a container to run hermesbaby (e.g. by using the Dockerfile from `hermersbaby/ci/Dockerfile`) you add
```
"containerEnv": {
    "DEVCONTAINER": "true"
}
```
to your devcontainer.json and this will tell `hb html-live` and `hb pdf-live` at an internal interface which is forwareded by VSCode/Docker.
The browser will not open automatically but VSCode asks you if you want to open a browser on the newly opened port.